### PR TITLE
export to extStats

### DIFF
--- a/spdmerlin.sh
+++ b/spdmerlin.sh
@@ -1185,6 +1185,12 @@ Generate_SPDStats(){
 					
 					rm -f "$tmpfile"
 					rm -f "/tmp/spd-stats.sql"
+
+					#extStats
+					extStats="/jffs/addons/extstats.d/mod_spdstats.sh"
+					if [ -f "$extStats" ]; then
+						$extStats "ext" $download $upload
+					fi
 				fi
 			done
 			


### PR DESCRIPTION
this should work to export your infos into extStats.
If my addon is not installed or the settings are set to not export sdpStats, nothing happend.