### PR TITLE
v4.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ spdMerlin is an internet speedtest and monitoring tool for AsusWRT Merlin with c
 spdMerlin is free to use under the [GNU General Public License version 3](https://opensource.org/licenses/GPL-3.0) (GPL 3.0).
 
 spdMerlin uses [Speedtest CLI](https://www.speedtest.net/apps/cli) and includes the required licenses, which must be accepted on first run of Speedtest CLI.
-As of spdMerlin v4.4.0 the Asus built-in Ookla speedtest binary is used to run the speedtests
+As of spdMerlin v4.4.0 the Asus built-in Ookla speedtest binary is used to run the speedtests.
 
 A swap file is required, you can set one up easily by using amtm, which is built into the router.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/1e0da6475e3047d59b35e258a18b78fc)](https://www.codacy.com/app/jackyaz/spdMerlin?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=jackyaz/spdMerlin&amp;utm_campaign=Badge_Grade)
 ![Shellcheck](https://github.com/jackyaz/spdMerlin/actions/workflows/shellcheck.yml/badge.svg)
 
-## v4.3.0
-### Updated on 2021-07-01
+## v4.4.0
+### Updated on 2021-07-25
 ## About
 spdMerlin is an internet speedtest and monitoring tool for AsusWRT Merlin with charts for daily, weekly and monthly summaries. It tracks download/upload bandwidth as well as latency, jitter and packet loss.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ spdMerlin is an internet speedtest and monitoring tool for AsusWRT Merlin with c
 spdMerlin is free to use under the [GNU General Public License version 3](https://opensource.org/licenses/GPL-3.0) (GPL 3.0).
 
 spdMerlin uses [Speedtest CLI](https://www.speedtest.net/apps/cli) and includes the required licenses, which must be accepted on first run of Speedtest CLI.
+As of spdMerlin v4.4.0 the Asus built-in Ookla speedtest binary is used to run the speedtests
 
 A swap file is required, you can set one up easily by using amtm, which is built into the router.
 

--- a/spdmerlin.sh
+++ b/spdmerlin.sh
@@ -1360,9 +1360,11 @@ Run_Speedtest(){
 	
 	CONFIG_STRING=""
 	LICENSE_STRING="--accept-license --accept-gdpr"
+	PROC_NAME="speedtest"
 	if [ "$SPEEDTEST_BINARY" = /usr/sbin/ookla ]; then
 		CONFIG_STRING="-c http://www.speedtest.net/api/embed/vz0azjarf5enop8a/config"
 		LICENSE_STRING=""
+		PROC_NAME="ookla"
 	fi
 	
 	echo 'var spdteststatus = "InProgress";' > /tmp/detect_spdtest.js
@@ -1372,8 +1374,8 @@ Run_Speedtest(){
 	rm -f "$resultfile"
 	rm -f "$tmpfile"
 	
-	if [ -n "$(pidof speedtest)" ]; then
-		killall speedtest
+	if [ -n "$(pidof "$PROC_NAME")" ]; then
+		killall "$PROC_NAME" 2>/dev/null
 	fi
 	
 	if Check_Swap ; then
@@ -1469,13 +1471,13 @@ Run_Speedtest(){
 						Print_Output true "Starting speedtest using auto-selected server for $IFACE_NAME interface" "$PASS"
 						"$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$IFACE" --format="human-readable" --unit="Mbps" --progress="yes" $LICENSE_STRING | tee "$tmpfile" &
 						speedtestcount=0
-						while [ -n "$(pidof speedtest)" ] && [ "$speedtestcount" -lt 120 ]; do
+						while [ -n "$(pidof "$PROC_NAME")" ] && [ "$speedtestcount" -lt 120 ]; do
 							speedtestcount="$((speedtestcount + 1))"
 							sleep 1
 						done
 						if [ "$speedtestcount" -ge 120 ]; then
 							Print_Output true "Speedtest for $IFACE_NAME hung (> 2 mins), killing process" "$CRIT"
-							killall speedtest
+							killall "$PROC_NAME" 2>/dev/null
 							continue
 						fi
 					else
@@ -1483,26 +1485,26 @@ Run_Speedtest(){
 							Print_Output true "Starting speedtest using $speedtestservername for $IFACE_NAME interface" "$PASS"
 							"$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$IFACE" --server-id="$speedtestserverno" --format="human-readable" --unit="Mbps" --progress="yes" $LICENSE_STRING | tee "$tmpfile" &
 							speedtestcount=0
-							while [ -n "$(pidof speedtest)" ] && [ "$speedtestcount" -lt 120 ]; do
+							while [ -n "$(pidof "$PROC_NAME")" ] && [ "$speedtestcount" -lt 120 ]; do
 								speedtestcount="$((speedtestcount + 1))"
 								sleep 1
 							done
 							if [ "$speedtestcount" -ge 120 ]; then
 								Print_Output true "Speedtest for $IFACE_NAME hung (> 2 mins), killing process" "$CRIT"
-								killall speedtest
+								killall "$PROC_NAME" 2>/dev/null
 								continue
 							fi
 						else
 							Print_Output true "Starting speedtest using using auto-selected server for $IFACE_NAME interface" "$PASS"
 							"$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$IFACE" --format="human-readable" --unit="Mbps" --progress="yes" $LICENSE_STRING | tee "$tmpfile" &
 							speedtestcount=0
-							while [ -n "$(pidof speedtest)" ] && [ "$speedtestcount" -lt 120 ]; do
+							while [ -n "$(pidof "$PROC_NAME")" ] && [ "$speedtestcount" -lt 120 ]; do
 								speedtestcount="$((speedtestcount + 1))"
 								sleep 1
 							done
 							if [ "$speedtestcount" -ge 120 ]; then
 								Print_Output true "Speedtest for $IFACE_NAME hung (> 2 mins), killing process" "$CRIT"
-								killall speedtest
+								killall "$PROC_NAME" 2>/dev/null
 								continue
 							fi
 						fi
@@ -3339,8 +3341,12 @@ Menu_Uninstall(){
 	else
 		ps | grep -v grep | grep -v $$ | grep -i "$SCRIPT_NAME_LOWER" | grep generate | awk '{print $1}' | xargs kill -9 >/dev/null 2>&1
 	fi
-	if [ -n "$(pidof speedtest)" ]; then
-		killall speedtest
+	PROC_NAME="speedtest"
+	if [ "$SPEEDTEST_BINARY" = /usr/sbin/ookla ]; then
+		PROC_NAME="ookla"
+	fi
+	if [ -n "$(pidof "$PROC_NAME")" ]; then
+		killall "$PROC_NAME" 2>/dev/null
 	fi
 	Print_Output true "Removing $SCRIPT_NAME..." "$PASS"
 	Auto_Startup delete 2>/dev/null

--- a/spdmerlin.sh
+++ b/spdmerlin.sh
@@ -1470,7 +1470,7 @@ Run_Speedtest(){
 					if [ "$mode" = "auto" ]; then
 						Print_Output true "Starting speedtest using auto-selected server for $IFACE_NAME interface" "$PASS"
 						"$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$IFACE" --format="human-readable" --unit="Mbps" --progress="yes" $LICENSE_STRING | tee "$tmpfile" &
-						sleep 3
+						sleep 2
 						speedtestcount=0
 						while [ -n "$(pidof "$PROC_NAME")" ] && [ "$speedtestcount" -lt 120 ]; do
 							speedtestcount="$((speedtestcount + 1))"
@@ -1485,7 +1485,7 @@ Run_Speedtest(){
 						if [ "$speedtestserverno" -ne 0 ]; then
 							Print_Output true "Starting speedtest using $speedtestservername for $IFACE_NAME interface" "$PASS"
 							"$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$IFACE" --server-id="$speedtestserverno" --format="human-readable" --unit="Mbps" --progress="yes" $LICENSE_STRING | tee "$tmpfile" &
-							sleep 3
+							sleep 2
 							speedtestcount=0
 							while [ -n "$(pidof "$PROC_NAME")" ] && [ "$speedtestcount" -lt 120 ]; do
 								speedtestcount="$((speedtestcount + 1))"
@@ -1499,7 +1499,7 @@ Run_Speedtest(){
 						else
 							Print_Output true "Starting speedtest using using auto-selected server for $IFACE_NAME interface" "$PASS"
 							"$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$IFACE" --format="human-readable" --unit="Mbps" --progress="yes" $LICENSE_STRING | tee "$tmpfile" &
-							sleep 3
+							sleep 2
 							speedtestcount=0
 							while [ -n "$(pidof "$PROC_NAME")" ] && [ "$speedtestcount" -lt 120 ]; do
 								speedtestcount="$((speedtestcount + 1))"

--- a/spdmerlin.sh
+++ b/spdmerlin.sh
@@ -1164,10 +1164,12 @@ GenerateServerList(){
 	promptforservername="$2"
 	printf "Generating list of closest servers for %s...\\n\\n" "$1"
 	CONFIG_STRING=""
+	LICENSE_STRING="--accept-license --accept-gdpr"
 	if [ "$SPEEDTEST_BINARY" = /usr/sbin/ookla ]; then
 		CONFIG_STRING="-c http://www.speedtest.net/api/embed/vz0azjarf5enop8a/config"
+		LICENSE_STRING=""
 	fi
-	serverlist="$("$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$(Get_Interface_From_Name "$1")" --servers --format="json" --accept-license --accept-gdpr)" 2>/dev/null
+	serverlist="$("$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$(Get_Interface_From_Name "$1")" --servers --format="json" $LICENSE_STRING)" 2>/dev/null
 	if [ -z "$serverlist" ]; then
 		Print_Output true "Error retrieving server list for for $1" "$CRIT"
 		serverno="exit"
@@ -1259,8 +1261,10 @@ GenerateServerList_WebUI(){
 	rm -f "$SCRIPT_WEB_DIR/$serverlistfile.htm"
 	
 	CONFIG_STRING=""
+	LICENSE_STRING="--accept-license --accept-gdpr"
 	if [ "$SPEEDTEST_BINARY" = /usr/sbin/ookla ]; then
 		CONFIG_STRING="-c http://www.speedtest.net/api/embed/vz0azjarf5enop8a/config"
+		LICENSE_STRING=""
 	fi
 	
 	spdifacename="$1"
@@ -1279,7 +1283,7 @@ GenerateServerList_WebUI(){
 		IFACELIST="$(echo "$IFACELIST" | cut -c2-)"
 		
 		for IFACE_NAME in $IFACELIST; do
-			serverlist="$("$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$(Get_Interface_From_Name "$IFACE_NAME")" --servers --format="json" --accept-license --accept-gdpr)" 2>/dev/null
+			serverlist="$("$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$(Get_Interface_From_Name "$IFACE_NAME")" --servers --format="json" $LICENSE_STRING)" 2>/dev/null
 			servercount="$(echo "$serverlist" | jq '.servers | length')"
 			COUNTER=1
 			until [ $COUNTER -gt "$servercount" ]; do
@@ -1289,7 +1293,7 @@ GenerateServerList_WebUI(){
 			printf "-----\\n" >> "/tmp/$serverlistfile.tmp"
 		done
 	else
-		serverlist="$("$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$(Get_Interface_From_Name "$spdifacename")" --servers --format="json" --accept-license --accept-gdpr)" 2>/dev/null
+		serverlist="$("$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$(Get_Interface_From_Name "$spdifacename")" --servers --format="json" $LICENSE_STRING)" 2>/dev/null
 		servercount="$(echo "$serverlist" | jq '.servers | length')"
 		COUNTER=1
 		until [ $COUNTER -gt "$servercount" ]; do
@@ -1355,8 +1359,10 @@ Run_Speedtest(){
 	speedtestservername=""
 	
 	CONFIG_STRING=""
+	LICENSE_STRING="--accept-license --accept-gdpr"
 	if [ "$SPEEDTEST_BINARY" = /usr/sbin/ookla ]; then
 		CONFIG_STRING="-c http://www.speedtest.net/api/embed/vz0azjarf5enop8a/config"
+		LICENSE_STRING=""
 	fi
 	
 	echo 'var spdteststatus = "InProgress";' > /tmp/detect_spdtest.js
@@ -1461,7 +1467,7 @@ Run_Speedtest(){
 					
 					if [ "$mode" = "auto" ]; then
 						Print_Output true "Starting speedtest using auto-selected server for $IFACE_NAME interface" "$PASS"
-						"$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$IFACE" --format="human-readable" --unit="Mbps" --progress="yes" --accept-license --accept-gdpr | tee "$tmpfile" &
+						"$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$IFACE" --format="human-readable" --unit="Mbps" --progress="yes" $LICENSE_STRING | tee "$tmpfile" &
 						speedtestcount=0
 						while [ -n "$(pidof speedtest)" ] && [ "$speedtestcount" -lt 120 ]; do
 							speedtestcount="$((speedtestcount + 1))"
@@ -1475,7 +1481,7 @@ Run_Speedtest(){
 					else
 						if [ "$speedtestserverno" -ne 0 ]; then
 							Print_Output true "Starting speedtest using $speedtestservername for $IFACE_NAME interface" "$PASS"
-							"$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$IFACE" --server-id="$speedtestserverno" --format="human-readable" --unit="Mbps" --progress="yes" --accept-license --accept-gdpr | tee "$tmpfile" &
+							"$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$IFACE" --server-id="$speedtestserverno" --format="human-readable" --unit="Mbps" --progress="yes" $LICENSE_STRING | tee "$tmpfile" &
 							speedtestcount=0
 							while [ -n "$(pidof speedtest)" ] && [ "$speedtestcount" -lt 120 ]; do
 								speedtestcount="$((speedtestcount + 1))"
@@ -1488,7 +1494,7 @@ Run_Speedtest(){
 							fi
 						else
 							Print_Output true "Starting speedtest using using auto-selected server for $IFACE_NAME interface" "$PASS"
-							"$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$IFACE" --format="human-readable" --unit="Mbps" --progress="yes" --accept-license --accept-gdpr | tee "$tmpfile" &
+							"$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$IFACE" --format="human-readable" --unit="Mbps" --progress="yes" $LICENSE_STRING | tee "$tmpfile" &
 							speedtestcount=0
 							while [ -n "$(pidof speedtest)" ] && [ "$speedtestcount" -lt 120 ]; do
 								speedtestcount="$((speedtestcount + 1))"

--- a/spdmerlin.sh
+++ b/spdmerlin.sh
@@ -32,7 +32,7 @@
 readonly SCRIPT_NAME="spdMerlin"
 readonly SCRIPT_NAME_LOWER=$(echo $SCRIPT_NAME | tr 'A-Z' 'a-z')
 readonly SCRIPT_VERSION="v4.4.0"
-SCRIPT_BRANCH="develop"
+SCRIPT_BRANCH="master"
 SCRIPT_REPO="https://raw.githubusercontent.com/jackyaz/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME_LOWER.d"
 readonly SCRIPT_WEBPAGE_DIR="$(readlink /www/user)"

--- a/spdmerlin.sh
+++ b/spdmerlin.sh
@@ -578,19 +578,19 @@ Auto_ServiceEvent(){
 		create)
 			if [ -f /jffs/scripts/service-event ]; then
 				STARTUPLINECOUNT=$(grep -c '# '"$SCRIPT_NAME" /jffs/scripts/service-event)
-				STARTUPLINECOUNTEX=$(grep -cx "/jffs/scripts/$SCRIPT_NAME_LOWER service_event"' "$@" & # '"$SCRIPT_NAME" /jffs/scripts/service-event)
+				STARTUPLINECOUNTEX=$(grep -cx 'if echo "$2" | /bin/grep -q "'"$SCRIPT_NAME_LOWER"'"; then { /jffs/scripts/'"$SCRIPT_NAME_LOWER"' service_event "$@" & }; fi # '"$SCRIPT_NAME" /jffs/scripts/service-event)
 				
 				if [ "$STARTUPLINECOUNT" -gt 1 ] || { [ "$STARTUPLINECOUNTEX" -eq 0 ] && [ "$STARTUPLINECOUNT" -gt 0 ]; }; then
 					sed -i -e '/# '"$SCRIPT_NAME"'/d' /jffs/scripts/service-event
 				fi
 				
 				if [ "$STARTUPLINECOUNTEX" -eq 0 ]; then
-					echo "/jffs/scripts/$SCRIPT_NAME_LOWER service_event"' "$@" & # '"$SCRIPT_NAME" >> /jffs/scripts/service-event
+					echo 'if echo "$2" | /bin/grep -q "'"$SCRIPT_NAME_LOWER"'"; then { /jffs/scripts/'"$SCRIPT_NAME_LOWER"' service_event "$@" & }; fi # '"$SCRIPT_NAME" >> /jffs/scripts/service-event
 				fi
 			else
 				echo "#!/bin/sh" > /jffs/scripts/service-event
 				echo "" >> /jffs/scripts/service-event
-				echo "/jffs/scripts/$SCRIPT_NAME_LOWER service_event"' "$@" & # '"$SCRIPT_NAME" >> /jffs/scripts/service-event
+				echo 'if echo "$2" | /bin/grep -q "'"$SCRIPT_NAME_LOWER"'"; then { /jffs/scripts/'"$SCRIPT_NAME_LOWER"' service_event "$@" & }; fi # '"$SCRIPT_NAME" >> /jffs/scripts/service-event
 				chmod 0755 /jffs/scripts/service-event
 			fi
 		;;

--- a/spdmerlin.sh
+++ b/spdmerlin.sh
@@ -31,7 +31,7 @@
 ### Start of script variables ###
 readonly SCRIPT_NAME="spdMerlin"
 readonly SCRIPT_NAME_LOWER=$(echo $SCRIPT_NAME | tr 'A-Z' 'a-z')
-readonly SCRIPT_VERSION="v4.3.1"
+readonly SCRIPT_VERSION="v4.4.0"
 SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/jackyaz/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME_LOWER.d"

--- a/spdmerlin.sh
+++ b/spdmerlin.sh
@@ -30,8 +30,8 @@
 ### Start of script variables ###
 readonly SCRIPT_NAME="spdMerlin"
 readonly SCRIPT_NAME_LOWER=$(echo $SCRIPT_NAME | tr 'A-Z' 'a-z')
-readonly SCRIPT_VERSION="v4.3.0"
-SCRIPT_BRANCH="master"
+readonly SCRIPT_VERSION="v4.3.1"
+SCRIPT_BRANCH="develop"
 SCRIPT_REPO="https://raw.githubusercontent.com/jackyaz/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME_LOWER.d"
 readonly SCRIPT_WEBPAGE_DIR="$(readlink /www/user)"

--- a/spdmerlin.sh
+++ b/spdmerlin.sh
@@ -1470,6 +1470,7 @@ Run_Speedtest(){
 					if [ "$mode" = "auto" ]; then
 						Print_Output true "Starting speedtest using auto-selected server for $IFACE_NAME interface" "$PASS"
 						"$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$IFACE" --format="human-readable" --unit="Mbps" --progress="yes" $LICENSE_STRING | tee "$tmpfile" &
+						sleep 3
 						speedtestcount=0
 						while [ -n "$(pidof "$PROC_NAME")" ] && [ "$speedtestcount" -lt 120 ]; do
 							speedtestcount="$((speedtestcount + 1))"
@@ -1484,6 +1485,7 @@ Run_Speedtest(){
 						if [ "$speedtestserverno" -ne 0 ]; then
 							Print_Output true "Starting speedtest using $speedtestservername for $IFACE_NAME interface" "$PASS"
 							"$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$IFACE" --server-id="$speedtestserverno" --format="human-readable" --unit="Mbps" --progress="yes" $LICENSE_STRING | tee "$tmpfile" &
+							sleep 3
 							speedtestcount=0
 							while [ -n "$(pidof "$PROC_NAME")" ] && [ "$speedtestcount" -lt 120 ]; do
 								speedtestcount="$((speedtestcount + 1))"
@@ -1497,6 +1499,7 @@ Run_Speedtest(){
 						else
 							Print_Output true "Starting speedtest using using auto-selected server for $IFACE_NAME interface" "$PASS"
 							"$SPEEDTEST_BINARY" $CONFIG_STRING --interface="$IFACE" --format="human-readable" --unit="Mbps" --progress="yes" $LICENSE_STRING | tee "$tmpfile" &
+							sleep 3
 							speedtestcount=0
 							while [ -n "$(pidof "$PROC_NAME")" ] && [ "$speedtestcount" -lt 120 ]; do
 								speedtestcount="$((speedtestcount + 1))"

--- a/spdmerlin.sh
+++ b/spdmerlin.sh
@@ -23,6 +23,7 @@
 # shellcheck disable=SC2028
 # shellcheck disable=SC2039
 # shellcheck disable=SC2059
+# shellcheck disable=SC2086
 # shellcheck disable=SC2155
 # shellcheck disable=SC3045
 ##############################################################

--- a/spdmerlin.sh
+++ b/spdmerlin.sh
@@ -1375,7 +1375,7 @@ Run_Speedtest(){
 	rm -f "$tmpfile"
 	
 	if [ -n "$(pidof "$PROC_NAME")" ]; then
-		killall "$PROC_NAME" 2>/dev/null
+		killall -q "$PROC_NAME"
 	fi
 	
 	if Check_Swap ; then
@@ -1478,7 +1478,7 @@ Run_Speedtest(){
 						done
 						if [ "$speedtestcount" -ge 120 ]; then
 							Print_Output true "Speedtest for $IFACE_NAME hung (> 2 mins), killing process" "$CRIT"
-							killall "$PROC_NAME" 2>/dev/null
+							killall -q "$PROC_NAME"
 							continue
 						fi
 					else
@@ -1493,7 +1493,7 @@ Run_Speedtest(){
 							done
 							if [ "$speedtestcount" -ge 120 ]; then
 								Print_Output true "Speedtest for $IFACE_NAME hung (> 2 mins), killing process" "$CRIT"
-								killall "$PROC_NAME" 2>/dev/null
+								killall -q "$PROC_NAME"
 								continue
 							fi
 						else
@@ -1507,7 +1507,7 @@ Run_Speedtest(){
 							done
 							if [ "$speedtestcount" -ge 120 ]; then
 								Print_Output true "Speedtest for $IFACE_NAME hung (> 2 mins), killing process" "$CRIT"
-								killall "$PROC_NAME" 2>/dev/null
+								killall -q "$PROC_NAME"
 								continue
 							fi
 						fi
@@ -3349,7 +3349,7 @@ Menu_Uninstall(){
 		PROC_NAME="ookla"
 	fi
 	if [ -n "$(pidof "$PROC_NAME")" ]; then
-		killall "$PROC_NAME" 2>/dev/null
+		killall -q "$PROC_NAME"
 	fi
 	Print_Output true "Removing $SCRIPT_NAME..." "$PASS"
 	Auto_Startup delete 2>/dev/null

--- a/spdmerlin.sh
+++ b/spdmerlin.sh
@@ -3526,7 +3526,11 @@ if [ -z "$1" ]; then
 	if AutomaticMode check; then Auto_Cron create 2>/dev/null; else Auto_Cron delete 2>/dev/null; fi
 	Auto_ServiceEvent create 2>/dev/null
 	Shortcut_Script create
-	License_Acceptance load
+	if ! License_Acceptance load; then
+		if ! License_Acceptance accept; then
+			exit 1
+		fi
+	fi
 	ScriptHeader
 	MainMenu
 	exit 0

--- a/speedtest-cli-license
+++ b/speedtest-cli-license
@@ -1,0 +1,20 @@
+==============================================================================
+You may only use this Speedtest software and information generated
+from it for personal, non-commercial use, through a command line
+interface on a personal computer. Your use of this software is subject
+to the End User License Agreement, Terms of Use and Privacy Policy at
+these URLs:
+https://www.speedtest.net/about/eula
+https://www.speedtest.net/about/terms
+https://www.speedtest.net/about/privacy
+==============================================================================
+Ookla collects certain data through Speedtest that may be considered
+personally identifiable, such as your IP address, unique device
+identifiers or location. Ookla believes it has a legitimate interest
+to share this data with internet providers, hardware manufacturers and
+industry regulators to help them understand and create a better and
+faster internet. For further information including how the data may be
+shared, where the data may be transferred and Ookla's contact details,
+please see our Privacy Policy at:
+http://www.speedtest.net/privacy
+==============================================================================


### PR DESCRIPTION
NEW: On routers that support Asus' built-in speedtest, spdMerlin will now use the same binary
CHANGED: service-event hook is more selective when it calls spdMerlin
CHANGED: Licence acceptance is prompted on script install and must be accepted for spdMerlin to be installed.