### PR TITLE
Fixed code to get space available in USB drive

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Shellcheck](https://github.com/jackyaz/spdMerlin/actions/workflows/shellcheck.yml/badge.svg)
 
 ## v4.4.6
-### Updated on 2024-July-01
+### Updated on 2024-July-04
 ## About
 spdMerlin is an internet speedtest and monitoring tool for AsusWRT Merlin with charts for daily, weekly and monthly summaries. It tracks download/upload bandwidth as well as latency, jitter and packet loss.
 

--- a/spdmerlin.sh
+++ b/spdmerlin.sh
@@ -13,7 +13,7 @@
 ##         https://github.com/jackyaz/spdMerlin             ##
 ##                                                          ##
 ##############################################################
-# Last Modified: 2024-Jul-01
+# Last Modified: 2024-Jul-04
 #-------------------------------------------------------------
 
 ##############        Shellcheck directives      #############
@@ -2029,10 +2029,18 @@ Generate_CSVs(){
 	renice 0 $$
 }
 
-Reset_DB(){
+##----------------------------------------##
+## Modified by Martinski W. [2024-Jul-04] ##
+##----------------------------------------##
+# [Ported code over from "connmon" script] #
+Reset_DB()
+{
 	SIZEAVAIL="$(df -P -k "$SCRIPT_STORAGE_DIR" | awk '{print $4}' | tail -n 1)"
 	SIZEDB="$(ls -l "$SCRIPT_STORAGE_DIR/spdstats.db" | awk '{print $5}')"
-	if [ "$SIZEDB" -gt "$((SIZEAVAIL*1024))" ]; then
+	SIZEAVAIL="$(echo "$SIZEAVAIL" | awk '{printf("%s", $1 * 1024);}')"
+
+	if [ "$(echo "$SIZEAVAIL $SIZEDB" | awk -F ' ' '{print ($1 < $2)}')" -eq 1 ]
+	then
 		Print_Output true "Database size exceeds available space. $(ls -lh "$SCRIPT_STORAGE_DIR/spdstats.db" | awk '{print $5}')B is required to create backup." "$ERR"
 		return 1
 	else


### PR DESCRIPTION
Ported code over from "**connmon**" script that computes correctly the free space available in a USB-attached drive that has hundreds of GBytes free. The code also compares correctly the "Available space" vs the "Required space."
